### PR TITLE
Add CE metric and path toggle

### DIFF
--- a/app.R
+++ b/app.R
@@ -19,8 +19,7 @@ ui <- fluidPage(
                    min = -0.5, max = 0.5, step = 0.01),
       numericInput("gamma", "Risk Aversion (gamma)", value = 1, min = 0.1, max = 5,
                    step = 0.1),
-      checkboxInput("show_paths", "Show 20 Sample Paths", value = FALSE),
-      actionButton("run", "Run Simulation")
+      checkboxInput("show_paths", "Show 20 Sample Paths", value = FALSE)
     ),
     mainPanel(
       plotOutput("dcaPlot"),
@@ -33,7 +32,7 @@ ui <- fluidPage(
 )
 
 server <- function(input, output) {
-  results <- eventReactive(input$run, {
+  results <- reactive({
     months_seq <- 1:n_months
 
     mu_daily <- log(1 + input$mu) / 252

--- a/app.R
+++ b/app.R
@@ -19,10 +19,15 @@ ui <- fluidPage(
                    min = -0.5, max = 0.5, step = 0.01),
       numericInput("gamma", "Risk Aversion (gamma)", value = 1, min = 0.1, max = 5,
                    step = 0.1),
+      checkboxInput("show_paths", "Show 20 Sample Paths", value = FALSE),
       actionButton("run", "Run Simulation")
     ),
     mainPanel(
-      plotOutput("dcaPlot")
+      plotOutput("dcaPlot"),
+      conditionalPanel(
+        condition = "input.show_paths == true",
+        plotOutput("pathPlot")
+      )
     )
   )
 )
@@ -37,24 +42,45 @@ server <- function(input, output) {
 
     lsum <- simulate_dca(price_mc, months = 1, trades_per_month = 1,
                          gamma = input$gamma)
-    dca_eu <- sapply(months_seq, function(m) {
+    dca_ce <- sapply(months_seq, function(m) {
       simulate_dca(price_mc, months = m,
                    trades_per_month = input$trades,
-                   gamma = input$gamma)$EU
+                   gamma = input$gamma)$CE_ratio
     })
 
-    data.frame(month = months_seq, EU = dca_eu, lump_sum = lsum$EU)
+    list(
+      df = data.frame(month = months_seq,
+                      CE = dca_ce,
+                      lump_sum = lsum$CE_ratio),
+      prices = price_mc
+    )
   })
 
   output$dcaPlot <- renderPlot({
-    df <- results()
+    df <- results()$df
     if (nrow(df) == 0) return(NULL)
-    ggplot(df, aes(month, EU)) +
+    ggplot(df, aes(month, CE)) +
       geom_line(color = "steelblue") +
       geom_point(color = "steelblue", size = 2) +
       geom_hline(aes(yintercept = lump_sum), linetype = 2, color = "red") +
-      labs(x = "Number of Months", y = "Expected Utility",
+      labs(x = "Number of Months", y = "Certainty Equivalent",
            title = "DCA vs. Lump Sum") +
+      theme_minimal()
+  })
+
+  output$pathPlot <- renderPlot({
+    req(input$show_paths)
+    price_mc <- results()$prices
+    if (is.null(price_mc)) return(NULL)
+    pick <- sample(ncol(price_mc), 20)
+    df <- data.frame(
+      Day = rep(seq_len(nrow(price_mc)), times = 20),
+      Price = as.vector(price_mc[, pick]),
+      Path = rep(seq_len(20), each = nrow(price_mc))
+    )
+    ggplot(df, aes(Day, Price, group = Path)) +
+      geom_line(alpha = 0.6) +
+      labs(title = "20 Random Price Paths", y = "Price") +
       theme_minimal()
   })
 }


### PR DESCRIPTION
## Summary
- add a checkbox to optionally display 20 sample simulated price paths
- compute certainty equivalent instead of expected utility
- plot CE metrics and optional paths in the Shiny app

## Testing
- `Rscript -e "print('Running short test'); source('sim.R'); sim <- simulate_prices(10, 2, seed=1); print(dim(sim));"`

------
https://chatgpt.com/codex/tasks/task_e_686a6f6089b08330a0ebb446638a954e